### PR TITLE
feat: last_index pagination

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,6 @@ name = "curation"
 version = "0.1.0"
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [lib]
 crate-type = ["cdylib"]
 

--- a/candid/curation.did
+++ b/candid/curation.did
@@ -28,15 +28,14 @@ type Offer = record { fungible : principal; buyer : principal; price : nat };
 type QueryRequest = record {
   reverse : opt bool;
   traits : opt vec record { text; GenericValue };
-  page : nat64;
   count : opt nat64;
+  last_index : opt nat64;
   sort_key : text;
-  offset : opt nat64;
 };
 type QueryResponse = record {
   total : nat64;
   data : vec TokenData;
-  offset : nat64;
+  last_index : opt nat64;
   error : opt text;
 };
 type Result = variant { Ok; Err : text };

--- a/src/types.rs
+++ b/src/types.rs
@@ -42,9 +42,8 @@ pub enum GenericValue {
 #[derive(CandidType, Clone, Deserialize)]
 pub struct QueryRequest {
     pub sort_key: String,
-    pub page: usize,
+    pub last_index: Option<usize>,
     pub count: Option<usize>,
-    pub offset: Option<usize>,
     pub traits: Option<Vec<(String, GenericValue)>>,
     pub reverse: Option<bool>,
 }
@@ -52,7 +51,7 @@ pub struct QueryRequest {
 #[derive(CandidType, Clone, Debug)]
 pub struct QueryResponse {
     pub total: usize,
-    pub offset: usize,
+    pub last_index: Option<usize>,
     pub data: Vec<TokenData>,
     pub error: Option<String>,
 }

--- a/test/test.sh
+++ b/test/test.sh
@@ -39,15 +39,12 @@ for i in {0..14}; do
 done
 
 echo "-> query for all tokens"
-for page in {0..1}; do
-  printf "  $page: "
-  dfx canister call curation query "(
-    record {
-      sort_key=\"all\";
-      page=$page;
-    }
-  )"
-done
+printf "  $page: "
+dfx canister call curation query "(
+  record {
+    sort_key=\"all\";
+  }
+)"
 
 trait=${traits[$((RANDOM % ${#traits[@]}))]}
 echo "-> trait filter query for random single trait page 0 (Base: $trait), page 0"
@@ -55,7 +52,6 @@ printf
 dfx canister call curation query "(
   record {
     sort_key=\"all\";
-    page=0;
     traits=opt vec {
       record {
         \"Base\";
@@ -73,7 +69,6 @@ echo "-> trait filter query for multiple random traits (Base: $trait1 | $trait2)
 dfx canister call curation query "(
   record {
     sort_key=\"all\";
-    page=0;
     traits=opt vec {
       record {
         \"Base\";
@@ -112,14 +107,12 @@ echo "-> query for tokens by 'last_listing' (page 0)"
 dfx canister call curation query "(
   record {
     sort_key=\"last_listing\";
-    page=0;
   }
 )"
 echo "-> query for tokens by 'listing_price' (page 0)"
 dfx canister call curation query "(
   record {
     sort_key=\"listing_price\";
-    page=0;
   }
 )"
 
@@ -145,14 +138,12 @@ echo "-> query for tokens by 'last_offer' (page 0)"
 dfx canister call curation query "(
   record {
     sort_key=\"last_offer\";
-    page=0;
   }
 )"
 echo "-> query for tokens by 'offer_price' (page 0)"
 dfx canister call curation query "(
   record {
     sort_key=\"offer_price\";
-    page=0;
   }
 )"
 
@@ -172,14 +163,12 @@ echo "-> query for tokens by 'last_offer' (page 0)"
 dfx canister call curation query "(
   record {
     sort_key=\"last_offer\";
-    page=0;
   }
 )"
 echo "-> query for tokens by 'offer_price' (page 0)"
 dfx canister call curation query "(
   record {
     sort_key=\"offer_price\";
-    page=0;
   }
 )"
 
@@ -200,14 +189,12 @@ echo "-> query for tokens by 'last_offer' (page 0)"
 dfx canister call curation query "(
   record {
     sort_key=\"last_offer\";
-    page=0;
   }
 )"
 echo "-> query for tokens by 'offer_price' (page 0)"
 dfx canister call curation query "(
   record {
     sort_key=\"offer_price\";
-    page=0;
   }
 )"
 
@@ -242,48 +229,46 @@ echo "-> query for tokens by 'last_sale' (page 0)"
 dfx canister call curation query "(
   record {
     sort_key=\"last_sale\";
-    page=0;
   }
 )"
 echo "-> query for tokens by 'sale_price' (page 0)"
 dfx canister call curation query "(
   record {
     sort_key=\"sale_price\";
-    page=0;
   }
 )"
 
 
 echo "-> query for all tokens"
-for page in {0..0}; do
-  printf "  $page: "
-  dfx canister call curation query "(
-    record {
-      sort_key=\"all\";
-      page=0;
-    }
-  )"
-done
+printf "  $page: "
+dfx canister call curation query "(
+  record {
+    sort_key=\"all\";
+  }
+)"
 
-trait1=${traits[$((RANDOM % ${#traits[@]}))]}
-trait2=${traits[$((RANDOM % ${#traits[@]}))]}
-echo "-> ascending trait filter query for multiple random traits, sk=last_sale (Base: $trait1 | $trait2), page 0"
+echo "-> ascending trait filter query for multiple traits, sk=last_sale (Base: $traits[1] | $traits[2] | $traits[3]), page 0"
 dfx canister call curation query "(
   record {
     sort_key=\"last_sale\";
-    page=0;
     reverse=opt(true);
     traits=opt vec {
       record {
         \"Base\";
         variant {
-          \"TextContent\" = \"$trait1\"
+          \"TextContent\" = \"$traits[1]\"
         };
       };
       record {
         \"Base\";
         variant {
-          \"TextContent\" = \"$trait2\"
+          \"TextContent\" = \"$traits[2]\"
+        };
+      };
+      record {
+        \"Base\";
+        variant {
+          \"TextContent\" = \"$traits[3]\"
         };
       };
     };


### PR DESCRIPTION
Paginate by last index. This is a much better strategy that allows for pagination across filtered data, and avoid reiteration over data already computed as ignored by previous filter requests